### PR TITLE
fix(lh-fix): Image elements do not have explicit width and height

### DIFF
--- a/src/app/movies/movie-list/movie-list.component.html
+++ b/src/app/movies/movie-list/movie-list.component.html
@@ -4,8 +4,8 @@
   <div class="item" *ngFor="let movie of movies trackBy: movieById">
     <a [routerLink]="['/movie', movie.id]">
       <img *ngIf="movie.poster_path" [defaultImage]="'assets/images/no_poster_available.jpg'" [lazyLoad]="'https://image.tmdb.org/t/p/w185/' + movie.poster_path"
-        alt="poster movie">
-      <img *ngIf="!movie.poster_path" src="/assets/images/no_poster_available.jpg" alt="No poster available">
+        alt="poster movie" width="200px" height="343px">
+      <img *ngIf="!movie.poster_path" width="200px" height="343px" src="/assets/images/no_poster_available.jpg" alt="No poster available">
     </a>
     <h3>{{movie.title}}</h3>
     <button *ngIf="authService.user | async" aria-hidden="true" mat-icon-button class="btn-add" color="primary" (click)="addMovie(movie)"


### PR DESCRIPTION
# LH Issue

Image elements do not have explicit width and height
Set an explicit width and height on image elements to reduce layout shifts and improve CLS. Learn moreCLS
URL
Failing Elements
	
…w185/rTh4K5uw9….jpg(image.tmdb.org)
poster movie
<img _ngcontent-ltb-c77="" alt="poster movie" src="https://image.tmdb.org/t/p/w185//rTh4K5uw9HypmpGslcKd4QfHl93.jpg" class="ng-star-inserted ng-lazyloaded">

[LHCI Server](http://localhost:9001/app/projects/)