### PR TITLE
refactor(hub-movies): implement genres

### DIFF
--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -1,13 +1,13 @@
 <mat-sidenav-container class="app-shell-container">
   <mat-sidenav
-    *rxLet="[]"
-    [opened]="mobileQuery.matches ? 'false' : 'true'"
+    *rxLet="viewState$; let vs"
+    [opened]="!vs.isMobile"
     #snav
-    [mode]="mobileQuery.matches ? 'over' : 'side'"
-    [fixedInViewport]="mobileQuery.matches"
+    [mode]="vs.isMobile ? 'over' : 'side'"
+    [fixedInViewport]="vs.isMobile"
   >
     <nav class="navigation">
-      <a class="navigation--header" *ngIf="!mobileQuery.matches">
+      <a class="navigation--header" *ngIf="!vs.isMobile">
         <picture>
           <img
             class="logo-img"
@@ -23,9 +23,8 @@
       <h2 class="navigation--headline">Discover</h2>
       <a
         class="navigation--link"
-        [routerLink]="['/movies/popular']"
-        routerLinkActive="active"
-        (click)="closeSidenav(); resetPagination()"
+        [class.active]="vs.activeRoute === '/movies/popular'"
+        (click)="navTo('/movies', 'popular')"
       >
         <div class="navigation--menu-item">
           <mat-icon class="navigation--menu-item-icon">favorite</mat-icon>
@@ -34,9 +33,8 @@
       </a>
       <a
         class="navigation--link"
-        [routerLink]="['/movies/top_rated']"
-        routerLinkActive="active"
-        (click)="closeSidenav(); resetPagination()"
+        [class.active]="vs.activeRoute === '/movies/top_rated'"
+        (click)="navTo('/movies', 'top_rated')"
       >
         <div class="navigation--menu-item">
           <mat-icon class="navigation--menu-item-icon">whatshot</mat-icon>
@@ -45,9 +43,8 @@
       </a>
       <a
         class="navigation--link"
-        [routerLink]="['/movies/upcoming']"
-        routerLinkActive="active"
-        (click)="closeSidenav(); resetPagination()"
+        [class.active]="vs.activeRoute === '/movies/upcoming'"
+        (click)="navTo('/movies', 'upcoming')"
       >
         <div class="navigation--menu-item">
           <mat-icon class="navigation--menu-item-icon">calendar_today</mat-icon>
@@ -59,9 +56,8 @@
         <a
           *ngFor="let genre of genres$ | async; trackBy: trackByGenre"
           class="navigation--link"
-          [routerLink]="['/movies/' + genre.name.toLowerCase()]"
-          routerLinkActive="active"
-          (click)="closeSidenav(); resetPagination()"
+          [class.active]="vs.activeRoute === '/genre/' + genre.id"
+          (click)="navTo('/genre', genre.id)"
         >
           <div class="navigation--menu-item">
             <mat-icon class="navigation--menu-item-icon"

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -9,7 +9,11 @@ import {
 } from '@angular/core';
 import { MediaMatcher } from '@angular/cdk/layout';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
+import { fromEvent } from '@rx-angular/cdk';
+import { RxState } from '@rx-angular/state';
+import { pipe } from 'rxjs';
+import { filter, map, startWith } from 'rxjs/operators';
 import { AuthStateService } from '../auth/auth.state';
 import { TmdbAuthEffects } from '../auth/tmdbAuth.effects';
 import { StateService } from '../shared/service/state.service';
@@ -22,6 +26,7 @@ import { MovieGenreModel } from '../movies/model';
   // **🚀 Perf Tip:**
   // Use ChangeDetectionStrategy.OnPush in all components to reduce change detection & template re-evaluation
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [RxState],
 })
 export class AppShellComponent implements OnInit, OnDestroy {
   mobileQuery: MediaQueryList;
@@ -31,7 +36,13 @@ export class AppShellComponent implements OnInit, OnDestroy {
   private _mobileQueryListener: () => void;
   @ViewChild('snav', { static: true }) snav: any;
 
+  readonly viewState$ = this.state.select();
+
   constructor(
+    private state: RxState<{
+      activeRoute: string;
+      isMobile: boolean;
+    }>,
     public tmdbState: StateService,
     public authState: AuthStateService,
     public authEffects: TmdbAuthEffects,
@@ -41,9 +52,20 @@ export class AppShellComponent implements OnInit, OnDestroy {
     private snackbar: MatSnackBar
   ) {
     this.mobileQuery = media.matchMedia('(max-width: 1299px)');
-    this._mobileQueryListener = () => changeDetectorRef.detectChanges();
-    // tslint:disable-next-line: deprecation
-    this.mobileQuery.addListener(this._mobileQueryListener);
+    this.state.connect(
+      'isMobile',
+      fromEvent(this.mobileQuery, 'change').pipe(
+        map(() => this.mobileQuery.matches),
+        startWith(this.mobileQuery.matches)
+      )
+    );
+    this.state.connect(
+      'activeRoute',
+      this.router.events.pipe(
+        filter<NavigationEnd>((e) => e instanceof NavigationEnd),
+        map((e) => e.url)
+      )
+    );
   }
 
   ngOnInit() {}
@@ -71,6 +93,12 @@ export class AppShellComponent implements OnInit, OnDestroy {
     this.snackbar.open('Goodbye', '', { duration: 2000 });
 
     this.router.navigate(['/movies/now-playing']);
+  }
+
+  navTo(path: string, args: any) {
+    this.closeSidenav();
+    this.resetPagination();
+    this.router.navigate([path, args]);
   }
 
   closeSidenav() {

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -34,7 +34,7 @@ export class AppShellComponent implements OnInit, OnDestroy {
   lang: string;
   // tslint:disable-next-line: variable-name
   private _mobileQueryListener: () => void;
-  @ViewChild('snav', { static: true }) snav: any;
+  @ViewChild('snav') snav: any;
 
   readonly viewState$ = this.state.select();
 

--- a/src/app/movies/container/routes.ts
+++ b/src/app/movies/container/routes.ts
@@ -5,5 +5,5 @@ import { MovieComponent } from '../movie/movie.component';
 export const ROUTES: Routes = [
   { path: 'movies/:category', component: MoviesComponent },
   { path: 'movie/:id', component: MovieComponent },
-  { path: 'genre', component: MoviesComponent },
+  { path: 'genre/:genre', component: MoviesComponent },
 ];

--- a/src/app/shared/service/tmdb/tmdb2.service.ts
+++ b/src/app/shared/service/tmdb/tmdb2.service.ts
@@ -44,6 +44,7 @@ export class Tmdb2Service {
   private URL_GENRE_MOVIE_LIST = [this.baseUrl, 'genre', 'movie', 'list'].join(
     '/'
   );
+  private URL_MOVIE_GENRE = `${this.baseUrl}/discover/movie`;
   private URL_MOVIE = (id) => [this.baseUrl, 'movie', id].join('/');
   private URL_MOVIE_RECOMMENDATIONS = (id) =>
     [this.baseUrl, 'movie', id, 'recommendations'].join('/')
@@ -87,6 +88,15 @@ export class Tmdb2Service {
     this.http
       .get<{ genres: MovieGenreModel[] }>(this.URL_GENRE_MOVIE_LIST)
       .pipe(map(({ genres }) => genres))
+
+  getMovieGenre = (
+    genreId: string,
+    page: string = '1',
+    sortBy: string = 'popularity.desc'
+  ): Observable<{ results: MovieModel[] }> =>
+    this.http.get<{ results: MovieModel[] }>(this.URL_MOVIE_GENRE, {
+      params: { with_genres: genreId, page, sort_by: sortBy },
+    })
 
   getPersonMovies = (page: string, sortBy: string): Observable<MovieModel> =>
     this.http.get<MovieModel>(this.URL_GENRE_MOVIE_LIST, {


### PR DESCRIPTION
* implemented first working version for genres (no custom sorting, no pagination)
* used `RxState` for app-shell component to keep track of `isMobile` and `activeRoute` state. first path to zoneless in app-shell
* fixed hamburger-nav button
* removed routerLink directive and swapped with click binding


https://user-images.githubusercontent.com/4904455/127584935-806acfac-d01b-49fb-af5d-6cc558ad58d6.mp4


https://user-images.githubusercontent.com/4904455/127584928-458081b2-49fc-4603-a465-f4f2dc2f2016.mp4

